### PR TITLE
Add setup script and fix build issues

### DIFF
--- a/BUGS_AND_FIXES.md
+++ b/BUGS_AND_FIXES.md
@@ -5,6 +5,7 @@ Several source and test files contained leftover markdown sections beginning wit
 - `auth-service/src/main/java/com/mysillydreams/auth/controller/AuthController.java`
 - `user-service/src/main/java/com/mysillydreams/userservice/web/admin/AdminController.java`
 - multiple test classes in `user-service`
+- `auth-service/src/test/java/com/mysillydreams/auth/repository/AdminMfaConfigRepositoryIntegrationTest.java`
 
 **Fix**: remove the markdown fragments from the files so that only valid Java code remains. This has been applied in this PR.
 
@@ -27,6 +28,11 @@ The integration test attempts to obtain a free port using `TestRestTemplate.getF
 
 **Suggested Solution**: Replace with a utility such as `SocketUtils.findAvailableTcpPort()` from Spring or use `ServerSocket` to allocate a free port.
 
-## 4. Incomplete TODO placeholders
+## 4. Duplicate `<dependencies>` Block in `user-service/pom.xml`
+An extra `<dependencies>` section was accidentally committed around line 160 of the POM, causing Maven to fail parsing the file.
+
+**Fix**: Remove the duplicated block so that only one `<dependencies>` section remains.
+
+## 5. Incomplete TODO placeholders
 Several services contain TODO markers for security, OTP validation, or event verification logic. These do not break compilation but represent unfinished behaviour. Implement the missing logic as required by business rules.
 

--- a/auth-service/src/test/java/com/mysillydreams/auth/repository/AdminMfaConfigRepositoryIntegrationTest.java
+++ b/auth-service/src/test/java/com/mysillydreams/auth/repository/AdminMfaConfigRepositoryIntegrationTest.java
@@ -105,8 +105,3 @@ public class AdminMfaConfigRepositoryIntegrationTest extends AuthIntegrationTest
         assertThat(foundOpt).isNotPresent();
     }
 }
-```
-
-I need an `AuthIntegrationTestBase.java` similar to `UserIntegrationTestBase.java` but for the Auth-Service context. This base class would set up Testcontainers for PostgreSQL if Auth-Service uses its own DB, and provide necessary properties like `app.simple-encryption.secret-key`.
-
-`auth-service/src/test/java/com/mysillydreams/auth/config/AuthIntegrationTestBase.java`:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install system packages
+sudo apt-get update
+sudo apt-get install -y openjdk-17-jdk maven
+
+# Build all Maven modules without running tests
+for module in auth-service catalog-service delivery-service inventory-api inventory-core order-api order-core payment-service pricing-engine user-service e2e-tests; do
+  if [ -d "$module" ]; then
+    echo "Building $module..."
+    (cd "$module" && mvn -q package -DskipTests)
+  fi
+done
+
+echo "Setup complete."

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -159,20 +159,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <!-- Add springdoc-openapi dependency -->
-    <dependencies>
-        <!-- ... other dependencies ... -->
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.7.0</version> <!-- Align with version used in Auth-Service or use latest compatible -->
-        </dependency>
-    </dependencies>
-    <!-- Note: If existing <dependencies> block is already there, add it inside.
-         This diff assumes it's adding a new <dependencies> block or modifying one that only had the BOM.
-         The actual pom.xml has a large <dependencies> block. This needs to be an ADDITION to that.
-         Let's find the end of the existing dependencies block.
-    -->
 
     <build>
         <plugins>


### PR DESCRIPTION
## Summary
- repair `user-service` POM by removing duplicate `<dependencies>` block
- clean stray Markdown from `AdminMfaConfigRepositoryIntegrationTest`
- document newly found bugs
- add `scripts/setup.sh` to install JDK & Maven and build modules

## Testing
- `./scripts/verify-smoke.sh` *(fails: `kafkacat` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a781e61208323a76e7a414792f137